### PR TITLE
Check if ng-app exists without returning large object

### DIFF
--- a/lib/capybara/angular/waiter.rb
+++ b/lib/capybara/angular/waiter.rb
@@ -34,7 +34,7 @@ module Capybara
       end
 
       def angular_app?
-        page.evaluate_script "(typeof $ != 'undefined') && $('[ng-app]')"
+        page.evaluate_script "(typeof $ != 'undefined') && $('[ng-app]').length > 0"
       end
 
       def setup_ready


### PR DESCRIPTION
In my app, returning the hash slowed down the tests caused a lot of timeout errors
