### PR TITLE
Fix: Include require 'capybara/dsl'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.rvmrc
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/lib/capybara/angular.rb
+++ b/lib/capybara/angular.rb
@@ -1,4 +1,5 @@
 require "capybara"
+require "capybara/dsl"
 
 require_relative "angular/dsl"
 require_relative "angular/waiter"


### PR DESCRIPTION
Without requiring 'capybara/dsl', I was receiving an unitialized constant error. This fixes the problem. Here is a trace:

/Users/james/.rvm/gems/ruby-2.0.0-p195@medeo-rails/gems/capybara-angular-0.0.3/lib/capybara/angular/dsl.rb:4:in `<module:DSL>': uninitialized constant Capybara::DSL (NameError)
    from /Users/james/.rvm/gems/ruby-2.0.0-p195@medeo-rails/gems/capybara-angular-0.0.3/lib/capybara/angular/dsl.rb:3:in`module:Angular'
    from /Users/james/.rvm/gems/ruby-2.0.0-p195@medeo-rails/gems/capybara-angular-0.0.3/lib/capybara/angular/dsl.rb:2:in `<module:Capybara>'
    from /Users/james/.rvm/gems/ruby-2.0.0-p195@medeo-rails/gems/capybara-angular-0.0.3/lib/capybara/angular/dsl.rb:1:in`<top (required)>'
    from /Users/james/.rvm/gems/ruby-2.0.0-p195@medeo-rails/gems/capybara-angular-0.0.3/lib/capybara/angular.rb:3:in `require_relative'
    from /Users/james/.rvm/gems/ruby-2.0.0-p195@medeo-rails/gems/capybara-angular-0.0.3/lib/capybara/angular.rb:3:in`<top (required)>'
    from /Users/james/.rvm/gems/ruby-2.0.0-p195@medeo-rails/gems/bundler-1.3.5/lib/bundler/runtime.rb:81:in `require'
    from /Users/james/.rvm/gems/ruby-2.0.0-p195@medeo-rails/gems/bundler-1.3.5/lib/bundler/runtime.rb:81:in`rescue in block in require'
