### PR TITLE
Support for declaring angular apps using data attribute

### DIFF
--- a/lib/capybara/angular/waiter.rb
+++ b/lib/capybara/angular/waiter.rb
@@ -37,7 +37,7 @@ module Capybara
       def angular_app?
         begin
           js = "(typeof angular !== 'undefined') && "
-          js += "angular.element(document.querySelector('[ng-app]')).length > 0"
+          js += "angular.element(document.querySelector('[ng-app], [data-ng-app]')).length > 0"
           page.evaluate_script js
         rescue Capybara::NotSupportedByDriverError
           false
@@ -47,7 +47,7 @@ module Capybara
       def setup_ready
         page.execute_script <<-JS
           window.angularReady = false;
-          var app = angular.element(document.querySelector('[ng-app]'));
+          var app = angular.element(document.querySelector('[ng-app], [data-ng-app]'));
           var injector = app.injector();
 
           injector.invoke(function($browser) {


### PR DESCRIPTION
Eg: `data-ng-app` instead of `ng-app`

It would be nice to see this on master because we are using data attributes to play with angular directives in order to stick to html standards.

Thanks for your work and time! :) :+1: 
