### PR TITLE
Waiter quits waiting if the page is reloaded and no longer uses angular

### DIFF
--- a/lib/capybara/angular/waiter.rb
+++ b/lib/capybara/angular/waiter.rb
@@ -15,7 +15,10 @@ module Capybara
         start = Time.now
         until ready?
           timeout! if timeout?(start)
-          setup_ready if page_reloaded_on_wait?
+          if page_reloaded_on_wait?
+            return unless angular_app?
+            setup_ready
+          end
           sleep(0.01)
         end
       end


### PR DESCRIPTION
- fixes a timeout waiting for angular on transition between pages using angular and pages that do not
