### PR TITLE
Fix window.angularReady undefined and timeouts

### DIFF
--- a/lib/capybara/angular/waiter.rb
+++ b/lib/capybara/angular/waiter.rb
@@ -46,13 +46,16 @@ module Capybara
 
       def setup_ready
         page.execute_script <<-JS
-          window.angularReady = false;
-          var app = angular.element(document.querySelector('[ng-app], [data-ng-app]'));
-          var injector = app.injector();
-
-          injector.invoke(function($browser) {
-            $browser.notifyWhenNoOutstandingRequests(function() {
-              window.angularReady = true;
+          angular.element(document).ready(function() {
+            var app = angular.element(document.querySelector('[ng-app], [data-ng-app]'));
+            var injector = app.injector();
+            injector.invoke(function($browser) {
+              if ($browser.outstandingRequestCount > 0) {
+                window.angularReady = false;
+              }
+              $browser.notifyWhenNoOutstandingRequests(function() {
+                window.angularReady = true;
+              });
             });
           });
         JS


### PR DESCRIPTION
This should fix some issues like #3 and #11
`window.angularReady` was undefined because `injector` was not setting correctly. wrapping the code in `javascript angular.element(document).ready(function() {});` fixed that for me.

Timeouts were thrown because `window.angularReady = false;` was sometimes setting when there was no outstanding requests, therefore a callback to set `angularReady` to `true` was not fired.
