### PR TITLE
Use angular testability api

### DIFF
--- a/lib/capybara/angular/dsl.rb
+++ b/lib/capybara/angular/dsl.rb
@@ -10,12 +10,19 @@ module Capybara
       end
 
       def page
-        wait_until_angular_ready
+        wait_until_angular_ready unless @ignoring_angular
         Capybara.current_session
       end
 
       def wait_until_angular_ready
         Waiter.new(Capybara.current_session).wait_until_ready
+      end
+
+      def ignoring_angular
+        @ignoring_angular = true
+        yield
+      ensure
+        @ignoring_angular = false
       end
     end
   end

--- a/lib/capybara/angular/waiter.rb
+++ b/lib/capybara/angular/waiter.rb
@@ -48,18 +48,17 @@ module Capybara
 
       def setup_ready
         page.execute_script <<-JS
-          angular.element(document).ready(function() {
-            var app = angular.element(document.querySelector('[ng-app], [data-ng-app]'));
-            var injector = app.injector();
-            injector.invoke(function($browser) {
-              if ($browser.outstandingRequestCount > 0) {
-                window.angularReady = false;
-              }
-              $browser.notifyWhenNoOutstandingRequests(function() {
-                window.angularReady = true;
-              });
-            });
-          });
+          el = document.querySelector('body')
+          window.angularReady = false;
+
+          if (angular.getTestability) {
+            angular.getTestability(el).whenStable(function() { window.angularReady = true; });
+          } else {
+            $browser = angular.element(el).injector().get('$browser')
+
+            if ($browser.outstandingRequestCount > 0) { window.angularReady = false; }
+            $browser.notifyWhenNoOutstandingRequests(function() { window.angularReady = true; });
+          }
         JS
       end
 


### PR DESCRIPTION
I added the Angular testability API from [Protractor](https://github.com/angular/protractor) to make the waiter more reliable. I also added a method `#ignoring_angular` that you can wrap around code that you don't want to wait on.