### PR TITLE
Strict Mode Injection Failure

### DIFF
--- a/lib/capybara/angular/waiter.rb
+++ b/lib/capybara/angular/waiter.rb
@@ -51,14 +51,12 @@ module Capybara
           angular.element(document).ready(function() {
             var app = angular.element(document.querySelector('[ng-app], [data-ng-app]'));
             var injector = app.injector();
-            injector.invoke(function($browser) {
-              if ($browser.outstandingRequestCount > 0) {
-                window.angularReady = false;
-              }
+            injector.invoke(['$browser', function($browser) {
+              window.angularReady = false;
               $browser.notifyWhenNoOutstandingRequests(function() {
                 window.angularReady = true;
               });
-            });
+            }]);
           });
         JS
       end


### PR DESCRIPTION
One of the newer angular features is to force strict injection mode so angular won't try and use the function argument names.  We use this in our project to make sure things will minify correctly when we get to production.  

When this feature is one, trying to use `capybara-angular` throws the following exception:
```
        Error: [$injector:strictdi] function($browser) is not using explicit annotation and cannot be invoked in strict mode
        http://errors.angularjs.org/1.3.14/$injector/strictdi?p0=function(%24browser)
            at http://localhost:9876/assets/angular/angular.js?body=1:3458 in annotate
            at http://localhost:9876/assets/angular/angular.js?body=1:4164 in invoke
            ...
```