### PR TITLE
Fix for updated variable name in Capybara 2.5.0

### DIFF
--- a/capybara-angular.gemspec
+++ b/capybara-angular.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'capybara'
+  spec.add_dependency 'capybara', '>= 2.5.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/lib/capybara/angular.rb
+++ b/lib/capybara/angular.rb
@@ -6,12 +6,12 @@ require_relative "angular/waiter"
 
 module Capybara
   module Angular
-    def self.default_wait_time
-      @default_wait_time || Capybara.default_wait_time
+    def self.default_max_wait_time
+      @default_max_wait_time || Capybara.default_max_wait_time
     end
 
-    def self.default_wait_time=(timeout)
-      @default_wait_time = timeout
+    def self.default_max_wait_time=(timeout)
+      @default_max_wait_time = timeout
     end
   end
 end

--- a/lib/capybara/angular/waiter.rb
+++ b/lib/capybara/angular/waiter.rb
@@ -26,7 +26,7 @@ module Capybara
       private
 
       def timeout?(start)
-        Time.now - start > Capybara::Angular.default_wait_time
+        Time.now - start > Capybara::Angular.default_max_wait_time
       end
 
       def timeout!

--- a/spec/capybara/angular_spec.rb
+++ b/spec/capybara/angular_spec.rb
@@ -6,8 +6,8 @@ require 'capybara/angular'
 
 Capybara.default_driver = :poltergeist
 Capybara.app = Rack::Directory.new('spec/public')
-Capybara.default_wait_time = 2
-Capybara::Angular.default_wait_time = 10
+Capybara.default_max_wait_time = 2
+Capybara::Angular.default_max_wait_time = 10
 
 feature 'Waiting for angular' do
   include Capybara::Angular::DSL


### PR DESCRIPTION
In capybara 2.5.0, "default_wait_time" has been renamed "default_max_wait_time".  This update addresses that, and creates a hard requirement on having 2.5.0 since that variable didn't exist before that version.