### PR TITLE
Added a document ready condition to setup_ready

### DIFF
--- a/lib/capybara/angular/waiter.rb
+++ b/lib/capybara/angular/waiter.rb
@@ -51,14 +51,30 @@ module Capybara
           var el = document.querySelector('body')
           window.angularReady = false;
 
-          if (angular.getTestability) {
-            angular.getTestability(el).whenStable(function() { window.angularReady = true; });
-          } else {
-            var $browser = angular.element(el).injector().get('$browser');
-
-            if ($browser.outstandingRequestCount > 0) { window.angularReady = false; }
-            $browser.notifyWhenNoOutstandingRequests(function() { window.angularReady = true; });
+          function ready(fn) {
+            if (document.readyState != 'loading'){
+              fn();
+            } else if (document.addEventListener) {
+              document.addEventListener('DOMContentLoaded', fn);
+            } else {
+              document.attachEvent('onreadystatechange', function() {
+                if (document.readyState != 'loading')
+                  fn();
+              });
+            }
           }
+
+          ready(function () {
+            if (angular.getTestability) {
+              angular.getTestability(el).whenStable(function() { window.angularReady = true; });
+            } else {
+              var $browser = angular.element(el).injector().get('$browser');
+
+              if ($browser.outstandingRequestCount > 0) { window.angularReady = false; }
+              $browser.notifyWhenNoOutstandingRequests(function() { window.angularReady = true; });
+            }
+          });
+
         JS
       end
 


### PR DESCRIPTION
This fixed a bug I was having where I believe angular wasn't completely loaded, but capybara was still trying to do things:

````
Error: [ng:test] no injector found for element argument to getTestability
http://errors.angularjs.org/1.3.13/ng/test
    at http://localhost:9000/bower_components/angular/angular.js:1509 in getTestability
    at phantomjs://webpage.evaluate():5
    at phantomjs://webpage.evaluate():12
    at phantomjs://webpage.evaluate():12 (Capybara::Poltergeist::JavascriptError)
````