### PR TITLE
Properly Find the Angular Root Element

### DIFF
--- a/lib/capybara/angular/waiter.rb
+++ b/lib/capybara/angular/waiter.rb
@@ -48,7 +48,7 @@ module Capybara
 
       def setup_ready
         page.execute_script <<-JS
-          var el = document.querySelector('body')
+          var el = document.querySelector('[ng-app], [data-ng-app]');
           window.angularReady = false;
 
           if (angular.getTestability) {


### PR DESCRIPTION
Use the same method to get the angular root element as the function that tests for the existence of the angular app.  It's not always on the body.