### PR TITLE
Stop using `TimeoutError` since it's deprecated.

### DIFF
--- a/lib/capybara/angular/waiter.rb
+++ b/lib/capybara/angular/waiter.rb
@@ -30,7 +30,7 @@ module Capybara
       end
 
       def timeout!
-        raise TimeoutError.new("timeout while waiting for angular")
+        raise Timeout::Error.new("timeout while waiting for angular")
       end
 
       def ready?


### PR DESCRIPTION
In ruby 2.3.0 `TimeoutError` has been [deprecated](https://bugs.ruby-lang.org/issues/11344) in favour of `Timeout::Error`.