### PR TITLE
Add usage example for `ignoring_angular`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Use it as you would use regular Capybara API, however this time, you won't face 
 include Capybara::Angular::DSL
 ```
 
+If you need to run some code without caring about AngularJS, you can use `ignoring_angular` like this:
+```ruby
+ignoring_angular do
+  # Your AngularJS agnostic code goes here
+end
+```
+
 ## Limitations
 
 At the moment it works with AngularJS applications initialized with `ng-app`.


### PR DESCRIPTION
I was getting this error in tests which mixed Angular and non-Angular pages:

```
Capybara::Poltergeist::JavascriptError:
       One or more errors were raised in the Javascript code on the page. If you don't care about these errors, you can ignore them by setting js_errors: false in your Poltergeist configuration (see documentation for details).

       Error: [ng:test] no injector found for element argument to getTestability
       http://errors.angularjs.org/1.6.4/ng/test
       Error: [ng:test] no injector found for element argument to getTestability
       http://errors.angularjs.org/1.6.4/ng/test
           at http://127.0.0.1:53051/assets/application-2af9e568138a56f49b27a9f432fa1fea5c0b99802f5aa87e49b68fe041f67d92.js:25559 in getTestability
           at :6
           at :13
           at :13
```

So I browsed this gem's code and I found that there was a hidden method that would allow me to ignore Angular in those pages.

Now it's time to unhide `ignoring_angular` and document it's use.