### PR TITLE
Fix: setup_ready with delayed angular bootstrapping

### DIFF
--- a/spec/capybara/angular_spec.rb
+++ b/spec/capybara/angular_spec.rb
@@ -17,6 +17,11 @@ feature 'Waiting for angular' do
     timeout_page_should_have_waited
   end
 
+  scenario 'when manually bootstrapping an angular application after a delay' do
+    open_delayed_manual_bootstrap_page
+    timeout_page_should_have_waited
+  end
+
   scenario 'when using ng-app to bootstrap an application' do
     open_ng_app_bootstrap_page
     timeout_page_should_have_waited
@@ -29,6 +34,10 @@ feature 'Waiting for angular' do
 
   def open_manual_bootstrap_page
     visit '/manual.html'
+  end
+
+  def open_delayed_manual_bootstrap_page
+    visit '/delayed-manual.html'
   end
 
   def open_ng_app_bootstrap_page

--- a/spec/public/delayed-manual.html
+++ b/spec/public/delayed-manual.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+    <script src="/js/angular-1.5.8.js"></script>
+    <script src="/js/app.js"></script>
+</head>
+<body ng-controller="waitingController">
+{{text}}
+<script>
+    setTimeout(function() {
+      angular.bootstrap(document.body, ['app']);
+    }, 5000);
+</script>
+</body>
+</html>


### PR DESCRIPTION
This fix the problem when angular is bootstrapped after a delay, for example, load API before bootstrapping. This should fix #34 completely.