### PR TITLE
Handle pages that load angular javascript but aren't actually angular pages

### DIFF
--- a/lib/capybara/angular/waiter.js
+++ b/lib/capybara/angular/waiter.js
@@ -1,0 +1,53 @@
+// This script is injected from waiter.rb.  It is responsible for setting
+// window.capybaraAngularReady when either a) angular is ready, or b)
+// it determines the page is not an angular page.
+
+(function () {
+  "use strict";
+
+  window.capybaraAngularReady = false;
+
+  function ready() {
+    window.capybaraAngularReady = true;
+  }
+
+  function angularPresent() {
+    return window.angular !== undefined;
+  }
+
+  function element() {
+    return document.querySelector("[ng-app], [data-ng-app]") || document.querySelector("body");
+  }
+
+  function elementPresent() {
+    return element() !== undefined;
+  }
+
+  function setupTestability() {
+    try {
+      angular.getTestability(element()).whenStable(ready);
+    } catch (err) {
+      ready();
+    }
+  }
+
+  function setupInjector() {
+    try {
+      angular.element(element()).injector().get("$browser").notifyWhenNoOutstandingRequests(ready);
+    } catch (err) {
+      ready();
+    }
+  }
+
+  function setup() {
+    if (!angularPresent() || !elementPresent()) {
+      ready();
+    } else if (angular.getTestability) {
+      setupTestability();
+    } else {
+      setupInjector();
+    }
+  }
+
+  setup();
+}());

--- a/lib/capybara/angular/waiter.rb
+++ b/lib/capybara/angular/waiter.rb
@@ -1,6 +1,8 @@
 module Capybara
   module Angular
     class Waiter
+      WAITER_JS = IO.read(File.expand_path "../waiter.js", __FILE__)
+
       attr_accessor :page
 
       def initialize(page)
@@ -8,22 +10,23 @@ module Capybara
       end
 
       def wait_until_ready
-        return unless angular_app?
-
-        setup_ready
-
+        return unless driver_supports_js?
         start = Time.now
+
         until ready?
+          inject_waiter
           timeout! if timeout?(start)
-          if page_reloaded_on_wait?
-            return unless angular_app?
-            setup_ready
-          end
           sleep(0.01)
         end
       end
 
       private
+
+      def driver_supports_js?
+        page.evaluate_script "true"
+      rescue Capybara::NotSupportedByDriverError
+        false
+      end
 
       def timeout?(start)
         Time.now - start > Capybara::Angular.default_max_wait_time
@@ -33,57 +36,13 @@ module Capybara
         raise Timeout::Error.new("timeout while waiting for angular")
       end
 
+      def inject_waiter
+        return if page.evaluate_script("window.capybaraAngularReady !== undefined")
+        page.execute_script WAITER_JS
+      end
+
       def ready?
-        page.evaluate_script("window.angularReady")
-      end
-
-      def angular_app?
-        page.evaluate_script <<-JS
-          (function() {
-            if (!window.angular) {
-              return false;
-            }
-
-            var el = document.querySelector('[ng-app], [data-ng-app]') || document.querySelector('body');
-            if (!el) {
-              return false;
-            }
-
-            try {
-              if (angular.getTestability) {
-                return !!angular.getTestability(el);
-              } else {
-                return !!angular.element(el).injector();
-              }
-            } catch(err) {
-              return false;
-            }
-          }());
-        JS
-
-      rescue Capybara::NotSupportedByDriverError
-        false
-      end
-
-      def setup_ready
-        page.execute_script <<-JS
-          var el = document.querySelector('[ng-app], [data-ng-app]') || document.querySelector('body');
-
-          window.angularReady = false;
-
-          if (angular.getTestability) {
-            angular.getTestability(el).whenStable(function() { window.angularReady = true; });
-          } else {
-            var $browser = angular.element(el).injector().get('$browser');
-
-            if ($browser.outstandingRequestCount > 0) { window.angularReady = false; }
-            $browser.notifyWhenNoOutstandingRequests(function() { window.angularReady = true; });
-          }
-        JS
-      end
-
-      def page_reloaded_on_wait?
-        page.evaluate_script("window.angularReady === undefined")
+        page.evaluate_script("window.capybaraAngularReady === true")
       end
     end
   end

--- a/lib/capybara/angular/waiter.rb
+++ b/lib/capybara/angular/waiter.rb
@@ -38,8 +38,28 @@ module Capybara
       end
 
       def angular_app?
-        js = '!!window.angular'
-        page.evaluate_script js
+        page.evaluate_script <<-JS
+          (function() {
+            if (!window.angular) {
+              return false;
+            }
+
+            var el = document.querySelector('[ng-app], [data-ng-app]') || document.querySelector('body');
+            if (!el) {
+              return false;
+            }
+
+            try {
+              if (angular.getTestability) {
+                return !!angular.getTestability(el);
+              } else {
+                return !!angular.element(el).injector();
+              }
+            } catch(err) {
+              return false;
+            }
+          }());
+        JS
 
       rescue Capybara::NotSupportedByDriverError
         false

--- a/spec/capybara/angular_spec.rb
+++ b/spec/capybara/angular_spec.rb
@@ -27,6 +27,16 @@ feature 'Waiting for angular' do
     timeout_page_should_have_waited
   end
 
+  scenario 'when visiting a non-angular page' do
+    open_non_angular_page
+    non_angular_page_should_load
+  end
+
+  scenario 'when visiting a non-angular page that loads angular javascript' do
+    open_non_angular_page_with_angular_javascript
+    non_angular_page_should_load
+  end
+
   def open_manual_bootstrap_page
     visit '/manual.html'
   end
@@ -39,7 +49,19 @@ feature 'Waiting for angular' do
     visit '/ng-app-not-on-body.html'
   end
 
+  def open_non_angular_page
+    visit '/non-angular-page.html'
+  end
+
+  def open_non_angular_page_with_angular_javascript
+    visit '/non-angular-page-with-angular-javascript.html'
+  end
+
   def timeout_page_should_have_waited
     expect(page).to have_content('waited')
+  end
+
+  def non_angular_page_should_load
+    expect(page).to have_content('non-angular page')
   end
 end

--- a/spec/public/non-angular-page-with-angular-javascript.html
+++ b/spec/public/non-angular-page-with-angular-javascript.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+    <script src="/js/angular-1.5.8.js"></script>
+</head>
+<body>
+non-angular page
+</body>
+</html>

--- a/spec/public/non-angular-page.html
+++ b/spec/public/non-angular-page.html
@@ -1,0 +1,6 @@
+<html>
+<head/>
+<body>
+non-angular page
+</body>
+</html>


### PR DESCRIPTION
We have a relatively large rails app and have been steadily angularizing it over the past year or so.  Your gem has been very helpful in resolving race conditions in our feature specs.  Thanks for creating and releasing it!

Unfortunately, we've been unable to use the gem across the board for our feature specs because some of our pages are angular pages and some are not, but we load the angular javascript itself on all pages and the current waiter mechanism for capybara-angular can't handle that -- see the failing test added in https://github.com/wrozka/capybara-angular/commit/74ef3e4599633fc4a808fbb7d2b657f96241b85d.

To address the issue, I added the second commit, https://github.com/wrozka/capybara-angular/commit/6310b06f440eccc7f8715c56c8c74a4aaf38d4f9, which fixes the failing test from the first commit.  However, while working on the code base I realized it might be easier to refactor the client-side waiting a bit and added the third commit, https://github.com/wrozka/capybara-angular/commit/4616a75f140ad049c0f314f45759b47011f11836.

I realize this is a fair amount of change.  If you're happy with it, then so am I, but if you'd prefer to include only the first commit, or first and second commit, I'd understand entirely.  Or if you don't like the PR at all, let me know and I'd be happy to address any concerns I can.

Finally, I noticed the angular protractor code [jumps through quite a number of hoops](https://github.com/angular/protractor/blob/master/lib/clientsidescripts.js#L75-L228) to account for all the various combinations of angular 1 and 2 and the different ways to bootstrap everything.  I suspect there are still a number of unhandled cases, but at the very least this PR addresses one of them and the refactor might aid in addressing more.  It might even be possible to adapt the protractor waiter code wholesale for use in capybara-angular...