### PR TITLE
Add puma as a dev dependency

### DIFF
--- a/capybara-angular.gemspec
+++ b/capybara-angular.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "poltergeist"
+  spec.add_development_dependency "puma"
 end


### PR DESCRIPTION
Fix spec execution on Travis.

It seems later versions of capybara are defaulting to puma.  If the gem isn't present, we hit https://travis-ci.org/wrozka/capybara-angular/builds/378520151.  An alternative fix is to specify `Capybara.server = :webrick` but the rails community seems to be moving to puma anyway.